### PR TITLE
Fix for range parsing when there is space between comparator and version 

### DIFF
--- a/lib/node_semver/range.rb
+++ b/lib/node_semver/range.rb
@@ -72,6 +72,11 @@ module NodeSemver
     end
 
     def parse_whitespace(version)
+      # Make sure number are like >=1.0.0 not like >= 1.0.0
+      version.gsub!("> ", ">")
+      version.gsub!(">= ", ">=")
+      version.gsub!("< ", "<")
+
       arr = version.split("\s")
       # normally this is to parse ">=1.0.0 <2.0.0", but sometimes
       # ">= 1.0.0" goes here too


### PR DESCRIPTION
There is node package that have ranges like '>= 0.3.0 < 0.4.0' when they should be '>=0.3.0 <0.4.0'. Solution for this is to remove leading spaces to make sure that ranges are parsed right