### PR TITLE
Brutal fix for funky spaceship version comparing

### DIFF
--- a/lib/node_semver/instance.rb
+++ b/lib/node_semver/instance.rb
@@ -25,7 +25,18 @@ module NodeSemver
          [prerelease, other.prerelease].include?(nil)
         compare_prerelease(self, other)
       else
-        version <=> other.version
+        # Sometimes Space ship just messes things up
+        # For example '9.12.0 < 10.0.0' result is incorrect 
+        # So try to solve that with comparing first number
+        # If it's smaller we just move on and return that
+        # If that it not working then back to spaceship check
+        local_ver = version.split(".")
+        local_other_ver = other.version.split(".")
+        if (Integer(local_ver[0]) < Integer(local_other_ver[0]))
+           Integer(local_ver[0]) <=> Integer(local_other_ver[0])
+        else
+           version <=> other.version
+        end
       end
     end
 


### PR DESCRIPTION
For Example situation is '9.12.0 < 10.0.0'. It is correct that '9.12.0' is greater than '10.0.0' but it's still wrong. To fix that compare first numbers as integers and if it's doesn't work then drop-back to default spaceship comparing. This can be tested with package 'hexo-cli'